### PR TITLE
Include toolchain using QuPath-compatible Java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     // Apply the groovy Plugin to add support for Groovy
     id 'groovy'
     // To manage included native libraries, limiting to the current platform
-    // JavaCPP v1.5.8 (with QuPath v0.4.x) does not support Gradle 7.6+
     alias(libs.plugins.javacpp)
 }
 
@@ -25,4 +24,15 @@ sourceSets {
             srcDirs = ['scripts/']
         }
     }
+}
+
+/*
+ * Ensure Java compatibility matches QuPath, and include sources and javadocs if building jars.
+ */
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(libs.versions.jdk.get())
+    }
+    withSourcesJar()
+    withJavadocJar()
 }


### PR DESCRIPTION
Simplifies ensuring we can build successfully.